### PR TITLE
Change memory limit on installation in the settings.php #1

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -32,3 +32,16 @@ $local_settings = __DIR__ . "/settings.local.php";
 if (file_exists($local_settings)) {
   include $local_settings;
 }
+
+/**
+ * Change memory limit on installation.
+ * 
+ * This logic could be removed after the installation is complete.
+ */
+if (PHP_SAPI !== 'cli') {
+  if (defined('MAINTENANCE_MODE') && constant('MAINTENANCE_MODE') === 'install')
+    ini_set('memory_limit', '2048M');
+  else {
+    ini_set('memory_limit', '256M');
+  }
+}


### PR DESCRIPTION
### Problem/Motivation
Having errors while installation
And when the installation finishes 

### Proposed resolution
- Change memory limit to 2048M on installation in the settings.php
- This logic could be removed after the installation complete ( or the default 256M limit will be used)
